### PR TITLE
Issues #25 - Utilize Network Allocate Function

### DIFF
--- a/infoblox/provider.go
+++ b/infoblox/provider.go
@@ -1,10 +1,11 @@
 package infoblox
 
 import (
+	"time"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/infobloxopen/infoblox-go-client"
-	"time"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 //Provider returns a terraform.ResourceProvider.
@@ -62,13 +63,14 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"infoblox_network":        resourceNetwork(),
-			"infoblox_network_view":   resourceNetworkView(),
-			"infoblox_ip_allocation":  resourceIPAllocation(),
-			"infoblox_ip_association": resourceIPAssociation(),
-			"infoblox_a_record":       resourceARecord(),
-			"infoblox_cname_record":   resourceCNAMERecord(),
-			"infoblox_ptr_record":     resourcePTRRecord(),
+			"infoblox_network":            resourceNetwork(),
+			"infoblox_network_view":       resourceNetworkView(),
+			"infoblox_ip_allocation":      resourceIPAllocation(),
+			"infoblox_ip_association":     resourceIPAssociation(),
+			"infoblox_a_record":           resourceARecord(),
+			"infoblox_cname_record":       resourceCNAMERecord(),
+			"infoblox_ptr_record":         resourcePTRRecord(),
+			"infoblox_network_allocation": resourceNetworkAllocation(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"infoblox_network": dataSourceNetwork(),

--- a/infoblox/resource_infoblox_network_allocation.go
+++ b/infoblox/resource_infoblox_network_allocation.go
@@ -1,0 +1,163 @@
+package infoblox
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
+)
+
+func resourceNetworkAllocation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkAllocationCreate,
+		Read:   resourceNetworkAllocationRead,
+		Update: resourceNetworkAllocationUpdate,
+		Delete: resourceNetworkAllocationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"network_view_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "default",
+				Description: "Network view name available in NIOS Server.",
+			},
+			"network_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of your network block.",
+			},
+			"cidr": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The network block in cidr format.",
+			},
+			"tenant_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier of your tenant in cloud.",
+			},
+			"reserve_ip": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: "The no of IP's you want to reserve.",
+			},
+			"gateway": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "gateway ip address of your network block.By default first IPv4 address is set as gateway address.",
+				Computed:    true,
+			},
+			"prefix_length": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Prefix length of the network to be allocated.",
+			},
+		},
+	}
+}
+
+func resourceNetworkAllocationCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning network block Creation", resourceNetworkAllocationIDString(d))
+
+	networkViewName := d.Get("network_view_name").(string)
+	cidr := d.Get("cidr").(string)
+	networkName := d.Get("network_name").(string)
+	reserveIP := d.Get("reserve_ip").(int)
+	gateway := d.Get("gateway").(string)
+	prefixLength := d.Get("prefix_length").(string)
+	tenantID := d.Get("tenant_id").(string)
+	connector := m.(*ibclient.Connector)
+
+	ZeroMacAddr := "00:00:00:00:00:00"
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+	ea := make(ibclient.EA)
+
+	prefixUint, err := strconv.ParseUint(prefixLength, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error converting prefix to uint : %s", err)
+	}
+
+	nwname, err := objMgr.AllocateNetwork(networkViewName, cidr, uint(prefixUint), networkName)
+	if err != nil {
+		return fmt.Errorf("Creation of network block failed in network view (%s) : %s", networkViewName, err)
+	}
+
+	// Check whether gateway or ip address already allocated
+	gatewayIP, err := objMgr.GetFixedAddress(networkViewName, nwname.Cidr, gateway, "")
+	if err == nil && gatewayIP != nil {
+		fmt.Printf("Gateway already created")
+	} else if gatewayIP == nil {
+		gatewayIP, err = objMgr.AllocateIP(networkViewName, nwname.Cidr, gateway, ZeroMacAddr, "", ea)
+		if err != nil {
+			return fmt.Errorf("Gateway Creation failed in network block(%s) error: %s", nwname.Cidr, err)
+		}
+	}
+
+	for i := 1; i <= reserveIP; i++ {
+		_, err = objMgr.AllocateIP(networkViewName, nwname.Cidr, gateway, ZeroMacAddr, "", ea)
+		if err != nil {
+			return fmt.Errorf("Reservation in network block failed in network view(%s):%s", networkViewName, err)
+		}
+	}
+
+	d.Set("gateway", gatewayIP.IPAddress)
+	d.SetId(nwname.Ref)
+
+	log.Printf("[DEBUG] %s: Creation on network block complete", resourceNetworkAllocationIDString(d))
+	return resourceNetworkRead(d, m)
+}
+func resourceNetworkAllocationRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Reading the required network block", resourceNetworkAllocationIDString(d))
+
+	networkViewName := d.Get("network_view_name").(string)
+	tenantID := d.Get("tenant_id").(string)
+	connector := m.(*ibclient.Connector)
+
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+
+	obj, err := objMgr.GetNetworkwithref(d.Id())
+	if err != nil {
+		return fmt.Errorf("Getting Network block from network view (%s) failed : %s", networkViewName, err)
+	}
+	d.SetId(obj.Ref)
+	log.Printf("[DEBUG] %s: Completed reading network block", resourceNetworkAllocationIDString(d))
+	return nil
+}
+func resourceNetworkAllocationUpdate(d *schema.ResourceData, m interface{}) error {
+
+	return fmt.Errorf("network updation is not supported")
+}
+
+func resourceNetworkAllocationDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning Deletion of network block", resourceNetworkAllocationIDString(d))
+
+	networkViewName := d.Get("network_view_name").(string)
+	tenantID := d.Get("tenant_id").(string)
+	connector := m.(*ibclient.Connector)
+
+	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
+
+	_, err := objMgr.DeleteNetwork(d.Id(), d.Get("network_view_name").(string))
+	if err != nil {
+		return fmt.Errorf("Deletion of Network block failed from network view(%s): %s", networkViewName, err)
+	}
+	d.SetId("")
+
+	log.Printf("[DEBUG] %s: Deletion of network block complete", resourceNetworkAllocationIDString(d))
+	return nil
+}
+
+type resourceNetworkAllocationIDStringInterface interface {
+	Id() string
+}
+
+func resourceNetworkAllocationIDString(d resourceNetworkAllocationIDStringInterface) string {
+	id := d.Id()
+	if id == "" {
+		id = "<new resource>"
+	}
+	return fmt.Sprintf("infoblox_ip_allocation (ID = %s)", id)
+}


### PR DESCRIPTION
Fixes #25 

I started this as a separate resource called `infoblox_network_allocation` following the naming convention of the `infoblox_ip_allocation`.  The file is essentially a copy of the `infoblox_network` resource, so I there could be some improvements and consolidation that could happen.  I am just not sure exactly how as I am new to provider development.

Since the new provider is affectively using the same functions and the network create provider for Delete, Update, and Read functions, it would probably make more sense to use the function in the `infoblox_network` provider instead of rewriting them in this provider since they would essentially be the same.

I have some done some testing with this, and it seems to work fine.  If you would like for me to write a go test for it as well, I can work on that too.

Any feedback you might have will be appreciated!