### PR TITLE
Allow to create network without gateway

### DIFF
--- a/infoblox/resource_infoblox_network.go
+++ b/infoblox/resource_infoblox_network.go
@@ -73,14 +73,17 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Check whether gateway or ip address already allocated
-	gatewayIP, err := objMgr.GetFixedAddress(networkViewName, cidr, gateway, "")
-	if err == nil && gatewayIP != nil {
-		fmt.Printf("Gateway already created")
-	} else if gatewayIP == nil {
-		gatewayIP, err = objMgr.AllocateIP(networkViewName, cidr, gateway, ZeroMacAddr, "", ea)
-		if err != nil {
-			return fmt.Errorf("Gateway Creation failed in network block(%s) error: %s", cidr, err)
+	if gateway != "none" {
+		gatewayIP, err := objMgr.GetFixedAddress(networkViewName, cidr, gateway, "")
+		if err == nil && gatewayIP != nil {
+			fmt.Printf("Gateway already created")
+		} else if gatewayIP == nil {
+			gatewayIP, err = objMgr.AllocateIP(networkViewName, cidr, gateway, ZeroMacAddr, "", ea)
+			if err != nil {
+				return fmt.Errorf("Gateway Creation failed in network block(%s) error: %s", cidr, err)
+			}
 		}
+		d.Set("gateway", gatewayIP.IPAddress)
 	}
 
 	for i := 1; i <= reserveIP; i++ {
@@ -90,7 +93,6 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	d.Set("gateway", gatewayIP.IPAddress)
 	d.SetId(nwname.Ref)
 
 	log.Printf("[DEBUG] %s: Creation on network block complete", resourceNetworkIDString(d))


### PR DESCRIPTION
From NIOS perspective no gateway needs for a Network.
Network and Network container almost same objects.
Say, any Network could be converted into network container by adding subnetwork.
AllocateNework dows not work for network with assigned IPs inside.
So we need ability to create network without gateway.