### PR TITLE
Add ability to allocate next available network

### DIFF
--- a/infoblox/resource_infoblox_network.go
+++ b/infoblox/resource_infoblox_network.go
@@ -2,9 +2,10 @@ package infoblox
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/infobloxopen/infoblox-go-client"
 	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 func resourceNetwork() *schema.Resource {
@@ -48,6 +49,12 @@ func resourceNetwork() *schema.Resource {
 				Description: "gateway ip address of your network block.By default first IPv4 address is set as gateway address.",
 				Computed:    true,
 			},
+			"allocate_prefix_len": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     0,
+				Description: "Set parameter value>0 to allocate next available network with prefix=value from network container defined by cidr.",
+			},
 		},
 	}
 }
@@ -62,36 +69,46 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 	gateway := d.Get("gateway").(string)
 	tenantID := d.Get("tenant_id").(string)
 	connector := m.(*ibclient.Connector)
+	prefixLen := d.Get("allocate_prefix_len").(int)
 
 	ZeroMacAddr := "00:00:00:00:00:00"
 	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
 	ea := make(ibclient.EA)
 
-	nwname, err := objMgr.CreateNetwork(networkViewName, cidr, networkName)
-	if err != nil {
-		return fmt.Errorf("Creation of network block failed in network view (%s) : %s", networkViewName, err)
+	var network *ibclient.Network
+	var err error
+	if prefixLen > 0 {
+		network, err = objMgr.AllocateNetwork(networkViewName, cidr, uint(prefixLen), networkName)
+		if err != nil {
+			return fmt.Errorf("Allocation of network block failed in network view (%s) : %s", networkViewName, err)
+		}
+	} else {
+		network, err = objMgr.CreateNetwork(networkViewName, cidr, networkName)
+		if err != nil {
+			return fmt.Errorf("Creation of network block failed in network view (%s) : %s", networkViewName, err)
+		}
 	}
 
 	// Check whether gateway or ip address already allocated
-	gatewayIP, err := objMgr.GetFixedAddress(networkViewName, cidr, gateway, "")
+	gatewayIP, err := objMgr.GetFixedAddress(networkViewName, network.Cidr, gateway, "")
 	if err == nil && gatewayIP != nil {
 		fmt.Printf("Gateway already created")
 	} else if gatewayIP == nil {
-		gatewayIP, err = objMgr.AllocateIP(networkViewName, cidr, gateway, ZeroMacAddr, "", ea)
+		gatewayIP, err = objMgr.AllocateIP(networkViewName, network.Cidr, gateway, ZeroMacAddr, "", ea)
 		if err != nil {
-			return fmt.Errorf("Gateway Creation failed in network block(%s) error: %s", cidr, err)
+			return fmt.Errorf("Gateway Creation failed in network block(%s) error: %s", network.Cidr, err)
 		}
 	}
 
 	for i := 1; i <= reserveIP; i++ {
-		_, err = objMgr.AllocateIP(networkViewName, cidr, gateway, ZeroMacAddr, "", ea)
+		_, err = objMgr.AllocateIP(networkViewName, network.Cidr, gateway, ZeroMacAddr, "", ea)
 		if err != nil {
 			return fmt.Errorf("Reservation in network block failed in network view(%s):%s", networkViewName, err)
 		}
 	}
 
 	d.Set("gateway", gatewayIP.IPAddress)
-	d.SetId(nwname.Ref)
+	d.SetId(network.Ref)
 
 	log.Printf("[DEBUG] %s: Creation on network block complete", resourceNetworkIDString(d))
 	return resourceNetworkRead(d, m)

--- a/infoblox/resource_infoblox_network_test.go
+++ b/infoblox/resource_infoblox_network_test.go
@@ -2,10 +2,11 @@ package infoblox
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/infobloxopen/infoblox-go-client"
-	"testing"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 func TestAccresourceNetwork(t *testing.T) {
@@ -25,6 +26,24 @@ func TestAccresourceNetwork(t *testing.T) {
 				Config: testAccresourceNetworkUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCreateNetworkExists(t, "infoblox_network.foo", "10.10.0.0/24", "default", "demo-network"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccresourceNetwork_Allocate(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccresourceNetworkAllocate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCreateNetworkExists(t, "infoblox_network.foo0", "10.0.0.0/24", "default", "demo-network"),
+					testAccCreateNetworkExists(t, "infoblox_network.foo1", "10.0.1.0/24", "default", "demo-network"),
 				),
 			},
 		},
@@ -75,6 +94,27 @@ resource "infoblox_network" "foo"{
 	network_name="demo-network"
 	cidr="10.10.0.0/24"
 	tenant_id="foo"
+	}`)
+
+/*
+Right now no infoblox_network_container resource available
+So, before run acceptance test TestAccresourceNetwork_Allocate
+in default network view should be created network container 10.0.0.0/16
+*/
+var testAccresourceNetworkAllocate = fmt.Sprintf(`
+resource "infoblox_network" "foo0"{
+	network_view_name="default"
+	network_name="demo-network"
+	cidr="10.0.0.0/16"
+	tenant_id="foo"
+	allocate_prefix_len=24
+	}
+resource "infoblox_network" "foo1"{
+	network_view_name="default"
+	network_name="demo-network"
+	cidr="10.0.0.0/16"
+	tenant_id="foo"
+	allocate_prefix_len=24
 	}`)
 
 var testAccresourceNetworkUpdate = fmt.Sprintf(`


### PR DESCRIPTION
Added optional parameter allocate_prefix_len
When parameter set to value>0 ibclient.AllocateNetwork method used
to get next available network from network container defined by cidr

Acceptance test result:
=== RUN   TestAccresourceNetwork
--- PASS: TestAccresourceNetwork (0.69s)
=== RUN   TestAccresourceNetwork_Allocate
--- PASS: TestAccresourceNetwork_Allocate (0.70s)