### PR TITLE
Fix allocate network behaviour

### DIFF
--- a/infoblox/resource_infoblox_network_test.go
+++ b/infoblox/resource_infoblox_network_test.go
@@ -105,16 +105,16 @@ var testAccresourceNetworkAllocate = fmt.Sprintf(`
 resource "infoblox_network" "foo0"{
 	network_view_name="default"
 	network_name="demo-network"
-	cidr="10.0.0.0/16"
 	tenant_id="foo"
 	allocate_prefix_len=24
+	parent_cidr="10.0.0.0/16"
 	}
 resource "infoblox_network" "foo1"{
 	network_view_name="default"
 	network_name="demo-network"
-	cidr="10.0.0.0/16"
 	tenant_id="foo"
 	allocate_prefix_len=24
+	parent_cidr="10.0.0.0/16"
 	}`)
 
 var testAccresourceNetworkUpdate = fmt.Sprintf(`


### PR DESCRIPTION
To be able to use allocated network resource cidr in other terraform
resources cidr should strore actual data.
But current realisation does not store allocated cidr in resource
network. It can be found only inside network ref.

Add option 'parent_cidr' and set option 'cidr' computed to fix this
issue.