### PR TITLE
Fix a and ptr record

### DIFF
--- a/infoblox/resource_infoblox_a_record_test.go
+++ b/infoblox/resource_infoblox_a_record_test.go
@@ -2,10 +2,11 @@ package infoblox
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/infobloxopen/infoblox-go-client"
-	"testing"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 func TestAccResourceARecord(t *testing.T) {
@@ -19,6 +20,13 @@ func TestAccResourceARecord(t *testing.T) {
 				Config: testAccresourceARecordCreate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccARecordExists(t, "infoblox_a_record.foo", "10.0.0.0/24", "10.0.0.2", "test", "demo-network", "default", "a.com"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccresourceARecordAllocate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccARecordExists(t, "infoblox_a_record.foo1", "10.0.0.0/24", "10.0.0.1", "test", "demo-network", "default", "a.com"),
+					testAccARecordExists(t, "infoblox_a_record.foo2", "10.0.0.0/24", "10.0.0.2", "test", "demo-network", "default", "a.com"),
 				),
 			},
 			resource.TestStep{
@@ -72,18 +80,30 @@ func testAccARecordExists(t *testing.T, n string, cidr string, ipAddr string, ne
 
 var testAccresourceARecordCreate = fmt.Sprintf(`
 resource "infoblox_a_record" "foo"{
-	network_view_name="test"
 	vm_name="test-name"
-	dns_view="default"
 	zone="a.com"
-	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.2"
+	tenant_id="foo"
+	}`)
+
+var testAccresourceARecordAllocate = fmt.Sprintf(`
+resource "infoblox_a_record" "foo1"{
+	vm_name="test-name"
+	zone="a.com"
+	ip_addr=""
+	cidr="10.0.0.0/24"
+	tenant_id="foo"
+	}
+resource "infoblox_a_record" "foo2"{
+	vm_name="test-name"
+	zone="a.com"
+	ip_addr=""
+	cidr="10.0.0.0/24"
 	tenant_id="foo"
 	}`)
 
 var testAccresourceARecordUpdate = fmt.Sprintf(`
 resource "infoblox_a_record" "foo"{
-	network_view_name="test"
 	vm_name="test-name"
 	dns_view="default"
 	zone="a.com"

--- a/infoblox/resource_infoblox_ptr_record.go
+++ b/infoblox/resource_infoblox_ptr_record.go
@@ -2,9 +2,10 @@ package infoblox
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/infobloxopen/infoblox-go-client"
 	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 func resourcePTRRecord() *schema.Resource {
@@ -15,12 +16,6 @@ func resourcePTRRecord() *schema.Resource {
 		Delete: resourcePTRRecordDelete,
 
 		Schema: map[string]*schema.Schema{
-			"network_view_name": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "default",
-				Description: "Network view name available in Nios server.",
-			},
 			"vm_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -28,8 +23,8 @@ func resourcePTRRecord() *schema.Resource {
 			},
 			"cidr": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The address in cidr format.",
+				Optional:    true,
+				Description: "The network to allocate IP address when the ip_addr field is empty. Network address in cidr format.",
 			},
 			"zone": &schema.Schema{
 				Type:        schema.TypeString,
@@ -45,7 +40,7 @@ func resourcePTRRecord() *schema.Resource {
 			"ip_addr": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "IP address your instance in cloud.For static allocation ,set the field with valid IP. For dynamic allocation, leave this field empty.",
+				Description: "IP address your instance in cloud. For static allocation, set the field with valid IP. For dynamic allocation, leave this field empty and set the cidr field.",
 			},
 			"vm_id": &schema.Schema{
 				Type:        schema.TypeString,
@@ -64,7 +59,6 @@ func resourcePTRRecord() *schema.Resource {
 func resourcePTRRecordCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] %s: Beginning to create PTR record from  required network block", resourcePTRRecordIDString(d))
 
-	networkViewName := d.Get("network_view_name").(string)
 	//This is for record Name
 	recordName := d.Get("vm_name").(string)
 	ipAddr := d.Get("ip_addr").(string)
@@ -83,10 +77,15 @@ func resourcePTRRecordCreate(d *schema.ResourceData, m interface{}) error {
 	if vmID != "" {
 		ea["VM ID"] = vmID
 	}
+
+	if ipAddr == "" && cidr == "" {
+		return fmt.Errorf("Error creating PTR record: nether ip_addr nor cidr value provided.")
+	}
+
 	objMgr := ibclient.NewObjectManager(connector, "Terraform", tenantID)
 	//fqdn
 	name := recordName + "." + zone
-	recordPTR, err := objMgr.CreatePTRRecord(networkViewName, dnsView, name, cidr, ipAddr, ea)
+	recordPTR, err := objMgr.CreatePTRRecord(dnsView, dnsView, name, cidr, ipAddr, ea)
 	if err != nil {
 		return fmt.Errorf("Error creating PTR Record from network block(%s): %s", cidr, err)
 	}

--- a/infoblox/resource_infoblox_ptr_record.go
+++ b/infoblox/resource_infoblox_ptr_record.go
@@ -93,7 +93,7 @@ func resourcePTRRecordCreate(d *schema.ResourceData, m interface{}) error {
 	d.Set("recordName", name)
 	d.SetId(recordPTR.Ref)
 
-	log.Printf("[DEBUG] %s: Creation of PTR Record complete", resourceARecordIDString(d))
+	log.Printf("[DEBUG] %s: Creation of PTR Record complete", resourcePTRRecordIDString(d))
 	return resourcePTRRecordGet(d, m)
 }
 

--- a/infoblox/resource_infoblox_ptr_record_test.go
+++ b/infoblox/resource_infoblox_ptr_record_test.go
@@ -2,10 +2,11 @@ package infoblox
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/infobloxopen/infoblox-go-client"
-	"testing"
+	ibclient "github.com/infobloxopen/infoblox-go-client"
 )
 
 func TestAccResourcePTRRecord(t *testing.T) {
@@ -19,6 +20,13 @@ func TestAccResourcePTRRecord(t *testing.T) {
 				Config: testAccresourcePTRRecordCreate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccPTRRecordExists(t, "infoblox_ptr_record.foo", "10.0.0.0/24", "10.0.0.2", "test", "demo-network", "default", "a.com"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccresourcePTRRecordAllocate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccPTRRecordExists(t, "infoblox_ptr_record.foo1", "10.0.0.0/24", "10.0.0.1", "test", "demo-network", "default", "a.com"),
+					testAccPTRRecordExists(t, "infoblox_ptr_record.foo2", "10.0.0.0/24", "10.0.0.2", "test", "demo-network", "default", "a.com"),
 				),
 			},
 			resource.TestStep{
@@ -72,18 +80,30 @@ func testAccPTRRecordExists(t *testing.T, n string, cidr string, ipAddr string, 
 
 var testAccresourcePTRRecordCreate = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo"{
-	network_view_name="test"
 	vm_name="test-name"
-	dns_view="default"
 	zone="a.com"
-	cidr="10.0.0.0/24"
 	ip_addr="10.0.0.2"
+	tenant_id="foo"
+	}`)
+
+var testAccresourcePTRRecordAllocate = fmt.Sprintf(`
+resource "infoblox_ptr_record" "foo1"{
+	vm_name="test-name"
+	zone="a.com"
+	ip_addr=""
+	cidr="10.0.0.0/24"
+	tenant_id="foo"
+	}
+resource "infoblox_ptr_record" "foo2"{
+	vm_name="test-name"
+	zone="a.com"
+	ip_addr=""
+	cidr="10.0.0.0/24"
 	tenant_id="foo"
 	}`)
 
 var testAccresourcePTRRecordUpdate = fmt.Sprintf(`
 resource "infoblox_ptr_record" "foo"{
-	network_view_name="test"
 	vm_name="test-name"
 	dns_view="default"
 	zone="a.com"


### PR DESCRIPTION
Fix A and PTR records
    
Change field cidr description to notice that this is network address to allocate IP from when ip_addr is empty.
    
Update ip_addr description with info that parent network cidr should be set when ip address empty
    
Remove network_view_name - according to WAPI documentation view name used in IP allocation should be the same to dns view of record(I have no idea why infoblox-go-client expose parameter netviewname).
    
Added verification that cidr not empty when ip_addr is empty.